### PR TITLE
Add Jest test for createTask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/taskManager.test.js
+++ b/__tests__/taskManager.test.js
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+const {createTask, tasks} = require('../taskManager.js');
+
+describe('createTask', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="taskName" />
+      <input id="taskXP" />
+      <select id="taskRepeat"></select>
+    `;
+    localStorage.clear();
+    tasks.length = 0;
+  });
+
+  test('adds a task and saves to localStorage', () => {
+    document.getElementById('taskName').value = 'Test Task';
+    document.getElementById('taskXP').value = '5';
+    document.getElementById('taskRepeat').value = 'daily';
+
+    createTask();
+
+    expect(tasks.length).toBe(1);
+    const saved = JSON.parse(localStorage.getItem('mazi_custom_tasks'));
+    expect(saved.length).toBe(1);
+    expect(saved[0].text).toContain('Test Task');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "mazi-fieryfox",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.5",
+    "jest-environment-jsdom": "^30.0.5",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/taskManager.js
+++ b/taskManager.js
@@ -1,0 +1,52 @@
+const tasks = [];
+
+function saveTasks() {
+  const custom = tasks.filter(t => t.id >= 1000);
+  localStorage.setItem('mazi_custom_tasks', JSON.stringify(custom));
+}
+
+function loadTasks() {
+  const saved = localStorage.getItem('mazi_custom_tasks');
+  if (saved) {
+    const parsed = JSON.parse(saved);
+    parsed.forEach(t => tasks.push(t));
+  }
+}
+
+function formatRepeat(type) {
+  switch (type) {
+    case 'daily':
+      return '🔁 Daily';
+    case 'weekly':
+      return '🔂 Weekly';
+    case 'monthly':
+      return '📆 Monthly';
+    default:
+      return '';
+  }
+}
+
+function createTask() {
+  const nameEl = document.getElementById('taskName');
+  const xpEl = document.getElementById('taskXP');
+  const repeatEl = document.getElementById('taskRepeat');
+  if (!nameEl || !xpEl || !repeatEl) return;
+
+  const name = nameEl.value.trim();
+  const xp = parseInt(xpEl.value.trim(), 10);
+  const repeat = repeatEl.value;
+
+  if (!name || isNaN(xp)) return;
+
+  const id = Date.now();
+  const newTask = {
+    id,
+    text: `${name} • ${formatRepeat(repeat)}`,
+    xp,
+  };
+
+  tasks.push(newTask);
+  saveTasks();
+}
+
+module.exports = { tasks, saveTasks, loadTasks, formatRepeat, createTask };


### PR DESCRIPTION
## Summary
- set up Jest with jsdom
- implement a small task manager module
- add tests checking that `createTask` adds tasks and writes to local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688563577168832a84ac1a9868f24597