### PR TITLE
Add level tracking for XP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MaZi FieryFox RPG
 
-MaZi FieryFox is a lightweight browser RPG prototype. It features a simple task list, companions that can be unlocked via a gacha system, and a basic XP and coin economy.
+MaZi FieryFox is a lightweight browser RPG prototype. It features a simple task list, companions that can be unlocked via a gacha system, a basic XP and coin economy, and a level system that increases as you complete tasks.
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <div class="player-avatar"></div>
     <div class="player-info">
       <span class="player-name">Murky</span>
+      <span class="player-level">Lvl <span id="playerLevel">1</span></span>
       <div class="xp-bar">
         <div class="xp-fill" id="xpFill"></div>
       </div>

--- a/script.js
+++ b/script.js
@@ -246,6 +246,12 @@ function updateXPBar() {
   const xp = getXP();
   const pct = Math.min(100, (xp % 100));
   bar.style.width = pct + '%';
+
+  const levelEl = document.getElementById('playerLevel');
+  if (levelEl) {
+    const level = Math.floor(xp / 100) + 1;
+    levelEl.textContent = level;
+  }
 }
 
 // -- Create Task Logic --

--- a/style.css
+++ b/style.css
@@ -6,6 +6,30 @@ body {
   padding: 1rem;
 }
 
+#top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.player-avatar {
+  width: 40px;
+  height: 40px;
+  background: #d8d8d8;
+  border-radius: 50%;
+}
+
+.player-info {
+  flex: 1;
+  margin: 0 1rem;
+}
+
+.player-level {
+  display: block;
+  font-weight: bold;
+  margin-top: 2px;
+}
+
 h1, h2 {
   text-align: center;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- add player level display in the header
- style top bar and level UI
- compute level based on total XP
- document level system in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68856e365a94832a8ca8638db44eb438