### PR TITLE
Move task helpers to dedicated module

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
   <div id="modal-overlay" style="display: none;"></div>
 
   <!-- MAIN SCRIPT -->
+<script src="taskManager.js"></script>
   <script src="script.js"></script>
 
   <!-- BOND EVENT MODAL -->

--- a/script.js
+++ b/script.js
@@ -3,26 +3,8 @@ const sheetUrl = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vR2wIf1t5R2FnM
 const rarityWeights = { "Common": 70, "Rare": 25, "Epic": 5 };
 const RANK_UP_THRESHOLD = 3;
 
-const tasks = [
-  { id: 1, text: "Complete daily routine • 🔁 Daily", xp: 25 },
-  { id: 2, text: "Tidy up workspace • 🔁 Daily", xp: 15 },
-  { id: 3, text: "Drink 2L water • 🔁 Daily", xp: 10 },
-  { id: 4, text: "Finish a new quest • 🔂 Weekly", xp: 25 },
-  { id: 5, text: "Read for 20 minutes • 📆 Monthly", xp: 20 }
-];
-
-function loadTasks() {
-  const saved = localStorage.getItem('mazi_custom_tasks');
-  if (saved) {
-    const parsed = JSON.parse(saved);
-    parsed.forEach(t => tasks.push(t));
-  }
-}
-
-function saveTasks() {
-  const custom = tasks.filter(t => t.id >= 1000);
-  localStorage.setItem('mazi_custom_tasks', JSON.stringify(custom));
-}
+const { tasks, loadTasks, saveTasks, createTask, formatRepeat } = window.TaskManager;
+window.createTask = createTask;
 
 // -- XP / Coin Progression --
 function getXP() { return parseInt(localStorage.getItem('mazi_xp') || '0'); }
@@ -263,38 +245,6 @@ function hideTaskModal() {
   document.getElementById("taskModal").classList.add("hidden");
 }
 
-function createTask() {
-  const name = document.getElementById("taskName").value.trim();
-  const xp = parseInt(document.getElementById("taskXP").value.trim(), 10);
-  const repeat = document.getElementById("taskRepeat").value;
-
-  if (!name || isNaN(xp)) return;
-
-  const id = Date.now(); // Unique timestamp-based ID
-  const newTask = {
-    id,
-    text: `${name} • ${formatRepeat(repeat)}`,
-    xp
-  };
-
-  tasks.push(newTask);
-  saveTasks();
-  displayTasks();
-
-  document.getElementById("taskName").value = "";
-  document.getElementById("taskXP").value = "";
-  document.getElementById("taskRepeat").value = "daily";
-  document.getElementById("taskModal").classList.add("hidden");
-}
-
-function formatRepeat(type) {
-  switch (type) {
-    case "daily": return "🔁 Daily";
-    case "weekly": return "🔂 Weekly";
-    case "monthly": return "📆 Monthly";
-    default: return "";
-  }
-}
 
 const companionBonds = {
   selene: { name: "Selene Graytail", bond: 0 },

--- a/taskManager.js
+++ b/taskManager.js
@@ -1,4 +1,10 @@
-const tasks = [];
+const tasks = [
+  { id: 1, text: "Complete daily routine • 🔁 Daily", xp: 25 },
+  { id: 2, text: "Tidy up workspace • 🔁 Daily", xp: 15 },
+  { id: 3, text: "Drink 2L water • 🔁 Daily", xp: 10 },
+  { id: 4, text: "Finish a new quest • 🔂 Weekly", xp: 25 },
+  { id: 5, text: "Read for 20 minutes • 📆 Monthly", xp: 20 }
+];
 
 function saveTasks() {
   const custom = tasks.filter(t => t.id >= 1000);
@@ -27,26 +33,34 @@ function formatRepeat(type) {
 }
 
 function createTask() {
-  const nameEl = document.getElementById('taskName');
-  const xpEl = document.getElementById('taskXP');
-  const repeatEl = document.getElementById('taskRepeat');
+  const nameEl = document.getElementById("taskName");
+  const xpEl = document.getElementById("taskXP");
+  const repeatEl = document.getElementById("taskRepeat");
   if (!nameEl || !xpEl || !repeatEl) return;
 
   const name = nameEl.value.trim();
   const xp = parseInt(xpEl.value.trim(), 10);
   const repeat = repeatEl.value;
-
   if (!name || isNaN(xp)) return;
 
   const id = Date.now();
-  const newTask = {
-    id,
-    text: `${name} • ${formatRepeat(repeat)}`,
-    xp,
-  };
-
+  const newTask = { id, text: `${name} • ${formatRepeat(repeat)}`, xp };
   tasks.push(newTask);
   saveTasks();
+  if (typeof displayTasks === "function") displayTasks();
+
+  nameEl.value = "";
+  xpEl.value = "";
+  repeatEl.value = "daily";
+  const modal = document.getElementById("taskModal");
+  if (modal) modal.classList.add("hidden");
 }
 
-module.exports = { tasks, saveTasks, loadTasks, formatRepeat, createTask };
+const TaskManager = { tasks, saveTasks, loadTasks, formatRepeat, createTask };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = TaskManager;
+}
+if (typeof window !== 'undefined') {
+  window.TaskManager = TaskManager;
+}


### PR DESCRIPTION
## Summary
- centralize task logic in `taskManager.js`
- expose module globally for browser and via CommonJS
- rely on `taskManager.js` from `script.js`
- load `taskManager.js` in `index.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885788dff50832aa00639737e4d53e7