### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <div class="coin-counter">
       <span id="coinCount">120</span> 🪙
     </div>
+    <button id="darkModeToggle" class="mode-toggle">🌙 Dark Mode</button>
   </header>
 
   <main id="game-container">

--- a/script.js
+++ b/script.js
@@ -245,6 +245,26 @@ function hideTaskModal() {
   document.getElementById("taskModal").classList.add("hidden");
 }
 
+function applyDarkMode(enabled) {
+  document.body.classList.toggle('dark-mode', enabled);
+  const toggleBtn = document.getElementById('darkModeToggle');
+  if (toggleBtn) {
+    toggleBtn.textContent = enabled ? '☀️ Light Mode' : '🌙 Dark Mode';
+  }
+  localStorage.setItem('mazi_dark_mode', enabled);
+}
+
+function initDarkMode() {
+  const enabled = localStorage.getItem('mazi_dark_mode') === 'true';
+  applyDarkMode(enabled);
+  const toggleBtn = document.getElementById('darkModeToggle');
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      applyDarkMode(!document.body.classList.contains('dark-mode'));
+    });
+  }
+}
+
 
 const companionBonds = {
   selene: { name: "Selene Graytail", bond: 0 },
@@ -368,6 +388,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Initial setup
   loadTasks();               // Load saved custom tasks
   ensureInitialUnlock();     // Unlock a starting companion
+  initDarkMode();            // Apply saved theme
   updateXPBar();             // Fill XP bar
   document.getElementById('coinCount').textContent = getCoins(); // Init coins
   displayTasks();            // Display tasks

--- a/style.css
+++ b/style.css
@@ -303,3 +303,34 @@ button {
   display: block;
   font-size: 0.75rem;
 }
+
+/* Dark Mode */
+.mode-toggle {
+  margin-left: 0.5rem;
+}
+body.dark-mode {
+  background: #181b21;
+  color: #f0f0f0;
+}
+body.dark-mode .task-card {
+  background: #2a2d34;
+  color: #f0f0f0;
+}
+body.dark-mode .task-card.completed {
+  background: #355834;
+  color: #d4edda;
+}
+body.dark-mode .modal-box {
+  background: #2a2d34;
+  color: #f0f0f0;
+}
+body.dark-mode #bottom-nav {
+  background: #333;
+  border-top-color: #555;
+}
+body.dark-mode #bottom-nav button {
+  color: #f0f0f0;
+}
+body.dark-mode #bottom-nav button.active {
+  border-top-color: #f4b860;
+}


### PR DESCRIPTION
## Summary
- enable dark mode UI
- save theme preference in localStorage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68857a897ef8832a96be4169217a1c04