### PR TITLE
Add chat log persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,20 @@
         <button class="gacha-button" data-count="10">Summon 10 (100🪙)</button>
       </div>
     </section>
+
+    <!-- CHAT TAB -->
+    <section id="chat-section" class="main-section">
+      <h2>Chat</h2>
+      <div id="chatMenu">Select a companion to chat with.</div>
+      <div id="chatWindow" class="hidden">
+        <div id="chatHistory"></div>
+        <input id="chatInput" type="text" placeholder="Say something..." />
+        <div>
+          <button id="sendChatBtn">Send</button>
+          <button id="closeChatBtn">Back</button>
+        </div>
+      </div>
+    </section>
   </main>
 
   <!-- BOTTOM NAVIGATION -->
@@ -95,6 +109,7 @@
     <button data-section="tasks-section">📋<span>Tasks</span></button>
     <button data-section="companions-section">💞<span>Companions</span></button>
     <button data-section="gacha-section">🎴<span>Gacha</span></button>
+    <button data-section="chat-section">💬<span>Chat</span></button>
   </nav>
 
   <!-- RESET BUTTON -->

--- a/style.css
+++ b/style.css
@@ -303,3 +303,32 @@ button {
   display: block;
   font-size: 0.75rem;
 }
+
+/* Chat Interface */
+#chatMenu button {
+  display: block;
+  margin: 0.5rem auto;
+  padding: 0.6rem 1rem;
+}
+#chatWindow.hidden {
+  display: none;
+}
+#chatHistory {
+  height: 200px;
+  overflow-y: auto;
+  background: #fffaf3;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+.chat-msg {
+  margin-bottom: 0.5rem;
+}
+.chat-msg.from-player {
+  text-align: right;
+  color: #1a73e8;
+}
+.chat-msg.from-companion {
+  text-align: left;
+  color: #3d2b1f;
+}


### PR DESCRIPTION
## Summary
- add default text to chat menu
- persist chat logs in localStorage and load them when reopening chats
- display placeholder when no companions are unlocked
- allow sending messages with the Enter key

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68857962ff84832aa5b2b7df50c91718