### PR TITLE
Implement repeat scheduling for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MaZi FieryFox RPG
 
-MaZi FieryFox is a lightweight browser RPG prototype. It features a simple task list, companions that can be unlocked via a gacha system, a basic XP and coin economy, and a level system that increases as you complete tasks.
+MaZi FieryFox is a lightweight browser RPG prototype. It features a simple task list, companions that can be unlocked via a gacha system, a basic XP and coin economy, and a level system that increases as you complete tasks. Tasks can now be scheduled to appear daily, weekly or monthly.
 
 ## Getting Started
 
@@ -26,3 +26,7 @@ Replace `YOUR_OPENAI_KEY` with your actual key.
 ## Saving Progress
 
 The game uses the browser's local storage to persist data. Custom tasks, completed tasks, earned XP, coins and unlocked companions are all stored locally so your progress remains even after refreshing or closing the tab.
+
+## Task Scheduling
+
+Tasks can be set to repeat on a daily, weekly or monthly cycle. Only tasks that are due for the current day will be displayed in the task list.

--- a/__tests__/schedule.test.js
+++ b/__tests__/schedule.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+const { shouldShowTaskToday } = require('../script.js');
+
+describe('shouldShowTaskToday', () => {
+  test('daily tasks always show', () => {
+    const task = { repeat: 'daily' };
+    const date = new Date('2023-08-15');
+    expect(shouldShowTaskToday(task, date)).toBe(true);
+  });
+
+  test('weekly tasks show on Monday', () => {
+    const task = { repeat: 'weekly' };
+    const monday = new Date('2023-08-14');
+    const tuesday = new Date('2023-08-15');
+    expect(shouldShowTaskToday(task, monday)).toBe(true);
+    expect(shouldShowTaskToday(task, tuesday)).toBe(false);
+  });
+
+  test('monthly tasks show on first of month', () => {
+    const task = { repeat: 'monthly' };
+    const first = new Date('2023-08-01');
+    const second = new Date('2023-08-02');
+    expect(shouldShowTaskToday(task, first)).toBe(true);
+    expect(shouldShowTaskToday(task, second)).toBe(false);
+  });
+});

--- a/__tests__/taskManager.test.js
+++ b/__tests__/taskManager.test.js
@@ -6,7 +6,11 @@ describe('createTask', () => {
     document.body.innerHTML = `
       <input id="taskName" />
       <input id="taskXP" />
-      <select id="taskRepeat"></select>
+      <select id="taskRepeat">
+        <option value="daily">Daily</option>
+        <option value="weekly">Weekly</option>
+        <option value="monthly">Monthly</option>
+      </select>
     `;
     localStorage.clear();
     tasks.length = 0;
@@ -23,5 +27,6 @@ describe('createTask', () => {
     const saved = JSON.parse(localStorage.getItem('mazi_custom_tasks'));
     expect(saved.length).toBe(1);
     expect(saved[0].text).toContain('Test Task');
+    expect(saved[0].repeat).toBe('daily');
   });
 });

--- a/script.js
+++ b/script.js
@@ -263,9 +263,18 @@ function displayTasks() {
   });
 }
 
-function shouldShowTaskToday(task) {
-  // Placeholder logic — always return true unless custom repeat logic is needed
-  return true;
+function shouldShowTaskToday(task, today = new Date()) {
+  const rep = task.repeat || 'daily';
+  switch (rep) {
+    case 'daily':
+      return true;
+    case 'weekly':
+      return today.getDay() === 1; // Monday
+    case 'monthly':
+      return today.getDate() === 1;
+    default:
+      return true;
+  }
 }
 
 function addXP(xp) {
@@ -693,5 +702,5 @@ if (typeof window !== 'undefined' && document.getElementById('bottom-nav')) {
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { addItem, getInventory };
+  module.exports = { addItem, getInventory, shouldShowTaskToday };
 }

--- a/taskManager.js
+++ b/taskManager.js
@@ -1,9 +1,9 @@
 const tasks = [
-  { id: 1, text: "Complete daily routine • 🔁 Daily", xp: 25 },
-  { id: 2, text: "Tidy up workspace • 🔁 Daily", xp: 15 },
-  { id: 3, text: "Drink 2L water • 🔁 Daily", xp: 10 },
-  { id: 4, text: "Finish a new quest • 🔂 Weekly", xp: 25 },
-  { id: 5, text: "Read for 20 minutes • 📆 Monthly", xp: 20 }
+  { id: 1, text: "Complete daily routine • 🔁 Daily", xp: 25, repeat: 'daily' },
+  { id: 2, text: "Tidy up workspace • 🔁 Daily", xp: 15, repeat: 'daily' },
+  { id: 3, text: "Drink 2L water • 🔁 Daily", xp: 10, repeat: 'daily' },
+  { id: 4, text: "Finish a new quest • 🔂 Weekly", xp: 25, repeat: 'weekly' },
+  { id: 5, text: "Read for 20 minutes • 📆 Monthly", xp: 20, repeat: 'monthly' }
 ];
 
 function saveTasks() {
@@ -44,7 +44,7 @@ function createTask() {
   if (!name || isNaN(xp)) return;
 
   const id = Date.now();
-  const newTask = { id, text: `${name} • ${formatRepeat(repeat)}`, xp };
+  const newTask = { id, text: `${name} • ${formatRepeat(repeat)}`, xp, repeat };
   tasks.push(newTask);
   saveTasks();
   if (typeof displayTasks === "function") displayTasks();


### PR DESCRIPTION
## Summary
- add repeat field to tasks
- create tasks with repeat field and show only when due
- expose `shouldShowTaskToday` for testing
- document new task scheduling feature
- add tests for task creation and schedule logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68858a36b794832a970d99d4a0e4bdf8