### PR TITLE
Fix tab navigation and remove global conflicts

### DIFF
--- a/__tests__/nav.test.js
+++ b/__tests__/nav.test.js
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+
+describe('navigation tabs', () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = html;
+    jest.resetModules();
+    // stub fetch to avoid network calls during init
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve('Name,Rarity\nTest,Common') })
+    );
+    // load taskManager and script after DOM is ready
+    require('../taskManager.js');
+    require('../script.js');
+  });
+
+  test('clicking nav buttons switches active section', () => {
+    const navButtons = document.querySelectorAll('#bottom-nav button');
+    const sections = document.querySelectorAll('.main-section');
+    expect(navButtons.length).toBeGreaterThan(1);
+    // Initially map-section is active
+    expect(document.getElementById('map-section').classList.contains('active')).toBe(true);
+    navButtons[1].click();
+    expect(document.getElementById('tasks-section').classList.contains('active')).toBe(true);
+    navButtons[0].click();
+    expect(document.getElementById('map-section').classList.contains('active')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid redeclaring global variables from TaskManager
- reference TaskManager functions/arrays through `TM` helper
- ensure navigation works when scripts load in browser

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68858e29820c832a829280d0ecd93b0f