### PR TITLE
Improve chat layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,14 +95,16 @@
     <!-- CHAT TAB -->
     <section id="chat-section" class="main-section">
       <h2>Chat</h2>
-      <div id="chatMenu" class="chat-inbox">Select a companion to chat with.</div>
-      <div id="chatWindow" class="hidden">
-        <div id="chatHistory"></div>
-        <div class="chat-input">
-          <input id="chatInput" type="text" placeholder="Say something..." />
-          <div>
-            <button id="sendChatBtn">Send</button>
-            <button id="closeChatBtn">Back</button>
+      <div class="chat-container">
+        <div id="chatMenu" class="chat-inbox">Select a companion to chat with.</div>
+        <div id="chatWindow" class="hidden">
+          <div id="chatHistory"></div>
+          <div class="chat-input">
+            <input id="chatInput" type="text" placeholder="Say something..." />
+            <div>
+              <button id="sendChatBtn">Send</button>
+              <button id="closeChatBtn">Back</button>
+            </div>
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -919,34 +919,45 @@ button {
 }
 
 /* Chat Interface */
-.chat-inbox {
+.chat-container {
   display: flex;
-  flex-direction: column;
+  gap: 1rem;
+}
+.chat-inbox {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1rem;
+  width: 40%;
+  max-width: 250px;
 }
 .chat-contact {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.6rem 1rem;
-  border-bottom: 1px solid #ddd;
+  padding: 1rem;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   cursor: pointer;
+  text-align: center;
 }
 .chat-contact:hover {
-  background: #f0f0f0;
+  background: #ffeac2;
 }
 .chat-avatar {
-  width: 40px;
-  height: 40px;
+  width: 60px;
+  height: 60px;
   border-radius: 50%;
   background-size: cover;
   background-position: center;
+  margin-bottom: 0.5rem;
 }
 .contact-info {
-  flex: 1;
   overflow: hidden;
 }
 .contact-name {
   font-weight: bold;
+  display: block;
 }
 .contact-preview {
   color: #666;
@@ -959,7 +970,7 @@ button {
   display: none;
 }
 #chatHistory {
-  height: 200px;
+  height: 300px;
   overflow-y: auto;
   background: #fffaf3;
   padding: 1rem;
@@ -968,14 +979,22 @@ button {
 }
 .chat-msg {
   margin-bottom: 0.5rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 12px;
+  display: inline-block;
 }
 .chat-msg.from-player {
   text-align: right;
   color: #1a73e8;
+  background: #e0f0ff;
+  margin-left: auto;
 }
 .chat-msg.from-companion {
   text-align: left;
   color: #3d2b1f;
+  background: #fff4dd;
+  margin-right: auto;
+}
 
 /* Dark Mode */
 .mode-toggle {
@@ -996,6 +1015,12 @@ body.dark-mode .task-card.completed {
 body.dark-mode .modal-box {
   background: #2a2d34;
   color: #f0f0f0;
+}
+body.dark-mode .chat-contact {
+  background: #2a2d34;
+}
+body.dark-mode #chatHistory {
+  background: #333;
 }
 body.dark-mode #bottom-nav {
   background: #333;


### PR DESCRIPTION
## Summary
- revamp chat menu with grid layout and cards
- use flex container for chat list and thread
- style conversation bubbles for player and companion

## Testing
- `npm test --silent`
- `npm test -- -i`


------
https://chatgpt.com/codex/tasks/task_e_68859684a5a0832a920b2f23d58a45ef