### PR TITLE
Fix dark mode styling

### DIFF
--- a/__tests__/darkMode.test.js
+++ b/__tests__/darkMode.test.js
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+
+describe('dark mode toggle', () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = html;
+    jest.resetModules();
+    // stub fetch to avoid network calls
+    global.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve('Name,Rarity\nTest,Common') }));
+    require('../taskManager.js');
+    require('../script.js');
+    document.dispatchEvent(new Event('DOMContentLoaded', { bubbles: true }));
+  });
+
+  test('clicking dark mode toggles class on body', () => {
+    const btn = document.getElementById('darkModeToggle');
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+    btn.click();
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+    btn.click();
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1012,6 +1012,7 @@ button {
   margin-right: auto;
   background: #ffe8cc;
   color: #3d2b1f;
+}
 
 /* Dark Mode */
 .mode-toggle {


### PR DESCRIPTION
## Summary
- close CSS rule for companion chat messages
- add Jest test for dark mode toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68859a940394832a8ee3498453026d59