### PR TITLE
Expand gacha loot pool

### DIFF
--- a/__tests__/inventory.test.js
+++ b/__tests__/inventory.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-const { addItem, getInventory } = require('../script.js');
+const { addItem, getInventory, performGacha } = require('../script.js');
 
 describe('inventory management', () => {
   beforeEach(() => {
@@ -11,5 +11,26 @@ describe('inventory management', () => {
     addItem('Potion');
     const inv = getInventory();
     expect(inv.Potion).toBe(2);
+  });
+
+  test('performGacha adds items to inventory', async () => {
+    // Stub companion data to avoid network fetch during the test
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve('Name,Rarity\nTest,Common') })
+    );
+
+    // Force random values so an item is awarded on the roll
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0)   // pick first companion
+      .mockReturnValueOnce(0.1) // trigger item drop
+      .mockReturnValueOnce(0);  // pick first item
+
+    await performGacha(1);
+    const inv = getInventory();
+    // First item in the pool should have been added
+    expect(inv.Potion).toBe(1);
+
+    Math.random.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- expand the item pool with more fantasy loot
- allow `performGacha` to return a promise and export it
- guard modal display helpers for non-browser environments
- test that gacha rolls add items to inventory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68859d4092a0832ab98305c01ad8c152