### PR TITLE
Add UI for setting OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ The game uses the browser's local storage to persist data. Custom tasks, complet
 
 Tasks can be set to repeat on a daily, weekly or monthly cycle. Only tasks that are due for the current day will be displayed in the task list.
 
+## OpenAI Features
+
+Some options such as AI quest generation use the OpenAI API. To enable these features, provide your own API key:
+
+1. Open the game in your browser and click the **API Key** button in the top bar.
+2. Enter your OpenAI API key when prompted. The key is saved to local storage under `openaiKey`.
+
+You can clear the key at any time by removing `openaiKey` from your browser's local storage.
+

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       <span id="coinCount">120</span> 🪙
     </div>
     <button id="darkModeToggle" class="mode-toggle">🌙 Dark Mode</button>
+    <button id="setApiKeyBtn" class="mode-toggle">🔑 API Key</button>
   </header>
 
   <main id="game-container">

--- a/script.js
+++ b/script.js
@@ -441,6 +441,14 @@ const bondQuotes = {
   ]
 };
 
+function promptForApiKey() {
+  const key = prompt('Enter your OpenAI API key:');
+  if (key) {
+    localStorage.setItem('openaiKey', key.trim());
+    alert('API key saved to local storage');
+  }
+}
+
 // -- Chatting with Companions --
 async function sendMessageToChatGPT(companionId, message) {
   const apiKey = localStorage.getItem('openaiKey');
@@ -757,6 +765,9 @@ function init() {
 
   const compBtn = document.getElementById('generateCompanionBtn');
   if (compBtn) compBtn.addEventListener('click', generateCompanionWithAI);
+
+  const apiBtn = document.getElementById('setApiKeyBtn');
+  if (apiBtn) apiBtn.addEventListener('click', promptForApiKey);
 
   // Chat send button
   // Add Task Button


### PR DESCRIPTION
## Summary
- add `API Key` button to header
- allow user to store OpenAI API key in localStorage
- document API key setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a0175a48832aa0b05e513ebbfa61