### PR TITLE
Add AI story generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ Tasks can be set to repeat on a daily, weekly or monthly cycle. Only tasks that 
 
 ## OpenAI Features
 
-Some options such as AI quest generation use the OpenAI API. To enable these features, provide your own API key:
+Some options such as AI quest and story generation use the OpenAI API. To enable these features, provide your own API key:
 
 1. Open the game in your browser and click the **API Key** button in the top bar.
 2. Enter your OpenAI API key when prompted. The key is saved to local storage under `openaiKey`.
 
 You can clear the key at any time by removing `openaiKey` from your browser's local storage.
+
+With a key set you can:
+ - Generate AI quests from the Tasks tab.
+ - Generate AI companions from the Gacha tab.
+ - Generate an AI story from the Map tab.
 

--- a/adventure.js
+++ b/adventure.js
@@ -106,10 +106,50 @@ function startAdventure() {
   showNode('start');
 }
 
+async function generateStoryWithAI() {
+  const apiKey = localStorage.getItem('openaiKey');
+  if (!apiKey) {
+    alert('OpenAI API key not found');
+    return;
+  }
+  const prompt = 'Write a short two sentence hook for a fantasy adventure.';
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }]
+  };
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + apiKey
+      },
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content?.trim();
+    if (text) {
+      const storyEl = document.getElementById('storyText');
+      const choiceEl = document.getElementById('choiceButtons');
+      if (storyEl) storyEl.textContent = text;
+      if (choiceEl) {
+        choiceEl.innerHTML = '';
+        const btn = document.createElement('button');
+        btn.textContent = 'Play Preset Adventure';
+        btn.onclick = startAdventure;
+        choiceEl.appendChild(btn);
+      }
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
 if (typeof window !== 'undefined') {
   window.startAdventure = startAdventure;
+  window.generateStoryWithAI = generateStoryWithAI;
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { storyNodes, showNode, startAdventure };
+  module.exports = { storyNodes, showNode, startAdventure, generateStoryWithAI };
 }

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
             <button id="attackBtn">Attack</button>
           </div>
           <button id="startAdventureBtn" onclick="startAdventure()">Start Adventure</button>
+          <button id="generateStoryBtn" onclick="generateStoryWithAI()">✨ Generate AI Story</button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- enable AI quest and story features in README
- allow generating a short story with OpenAI
- show a `Generate AI Story` button in the map section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a400d80c832aa51031f962b26cf4