### PR TITLE
Add easy add AI task feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The game uses the browser's local storage to persist data. Custom tasks, complet
 ## Task Scheduling
 
 Tasks can be set to repeat on a daily, weekly or monthly cycle. Only tasks that are due for the current day will be displayed in the task list.
+You can also use the **Easy Add** button to quickly create a one-time task from a short description like "Take out the trash tomorrow morning".
 
 ## OpenAI Features
 

--- a/__tests__/schedule.test.js
+++ b/__tests__/schedule.test.js
@@ -23,4 +23,12 @@ describe('shouldShowTaskToday', () => {
     expect(shouldShowTaskToday(task, first)).toBe(true);
     expect(shouldShowTaskToday(task, second)).toBe(false);
   });
+
+  test('once tasks show only on specified date', () => {
+    const task = { repeat: 'once', date: '2023-08-15' };
+    const day = new Date('2023-08-15');
+    const next = new Date('2023-08-16');
+    expect(shouldShowTaskToday(task, day)).toBe(true);
+    expect(shouldShowTaskToday(task, next)).toBe(false);
+  });
 });

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
       <p id="taskMilestoneDisplay">Tasks Completed: <span id="taskMilestone">0</span></p>
       <div id="taskList" class="task-category"></div>
       <button id="addTaskBtn">➕ Add New Task</button>
+      <button id="easyAddBtn">✨ Easy Add</button>
       <button id="generateQuestBtn">🎲 Generate AI Quest</button>
       <div id="taskModal" class="modal hidden">
         <div class="modal-box">

--- a/script.js
+++ b/script.js
@@ -323,6 +323,9 @@ function shouldShowTaskToday(task, today = new Date()) {
       return today.getDay() === 1; // Monday
     case 'monthly':
       return today.getDate() === 1;
+    case 'once':
+      if (!task.date) return false;
+      return new Date(task.date).toDateString() === today.toDateString();
     default:
       return true;
   }
@@ -773,6 +776,12 @@ function init() {
   // Add Task Button
   document.getElementById("addTaskBtn").addEventListener("click", () => {
     document.getElementById("taskModal").classList.remove("hidden");
+  });
+
+  const easyBtn = document.getElementById('easyAddBtn');
+  if (easyBtn) easyBtn.addEventListener('click', () => {
+    const txt = prompt('Describe your task:');
+    if (txt) TM.createTaskFromText(txt);
   });
 
 

--- a/taskManager.js
+++ b/taskManager.js
@@ -27,9 +27,44 @@ function formatRepeat(type) {
       return '🔂 Weekly';
     case 'monthly':
       return '📆 Monthly';
+    case 'once':
+      return '';
     default:
       return '';
   }
+}
+
+function parseNaturalTask(text) {
+  const lower = text.toLowerCase();
+  let time = 'morning';
+  if (lower.includes('afternoon')) time = 'afternoon';
+  else if (lower.includes('evening') || lower.includes('night')) time = 'evening';
+
+  let date = new Date();
+  if (lower.includes('tomorrow')) date.setDate(date.getDate() + 1);
+  const dateStr = date.toISOString().split('T')[0];
+
+  const name = text.replace(/\b(today|tomorrow|morning|afternoon|evening|night)\b/gi, '').trim();
+
+  return { name: name || text, time, date: dateStr };
+}
+
+function createTaskFromText(text) {
+  const parsed = parseNaturalTask(text);
+  const id = Date.now();
+  const xp = 10;
+  const newTask = {
+    id,
+    text: parsed.name,
+    xp,
+    repeat: 'once',
+    time: parsed.time,
+    date: parsed.date
+  };
+  tasks.push(newTask);
+  saveTasks();
+  if (typeof displayTasks === 'function') displayTasks();
+  return newTask;
 }
 
 function createTask() {
@@ -59,7 +94,15 @@ function createTask() {
   if (modal) modal.classList.add("hidden");
 }
 
-const TaskManager = { tasks, saveTasks, loadTasks, formatRepeat, createTask };
+const TaskManager = {
+  tasks,
+  saveTasks,
+  loadTasks,
+  formatRepeat,
+  createTask,
+  parseNaturalTask,
+  createTaskFromText
+};
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = TaskManager;


### PR DESCRIPTION
## Summary
- allow one-time tasks in scheduling logic
- support easy task creation from plain text
- provide button for new quick-add workflow
- document easy add feature
- test once-only scheduling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885aa85dffc832a9a151c5d970617dd