### PR TITLE
Add one time task option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The game uses the browser's local storage to persist data. Custom tasks, complet
 
 ## Task Scheduling
 
-Tasks can be set to repeat on a daily, weekly or monthly cycle. Only tasks that are due for the current day will be displayed in the task list.
-You can also use the **Easy Add** button to quickly create a one-time task from a short description like "Take out the trash tomorrow morning".
+Tasks can be set to repeat on a daily, weekly, monthly or **one time** cycle. Only tasks that are due for the current day will be displayed in the task list.
+You can also use the **Easy Add** button to quickly create a one-time task from a short description like "Take out the trash tomorrow morning" or pick **One Time** from the task creation dialog and specify a date.
 
 ## OpenAI Features
 

--- a/__tests__/taskManager.test.js
+++ b/__tests__/taskManager.test.js
@@ -11,10 +11,12 @@ describe('createTask', () => {
         <option value="afternoon">Afternoon</option>
         <option value="evening">Evening</option>
       </select>
+      <input id="taskDate" />
       <select id="taskRepeat">
         <option value="daily">Daily</option>
         <option value="weekly">Weekly</option>
         <option value="monthly">Monthly</option>
+        <option value="once">Once</option>
       </select>
     `;
     localStorage.clear();
@@ -34,5 +36,19 @@ describe('createTask', () => {
     expect(saved.length).toBe(1);
     expect(saved[0].text).toContain('Test Task');
     expect(saved[0].repeat).toBe('daily');
+  });
+
+  test('adds a one time task with date', () => {
+    document.getElementById('taskName').value = 'One Time';
+    document.getElementById('taskXP').value = '3';
+    document.getElementById('taskTime').value = 'evening';
+    document.getElementById('taskRepeat').value = 'once';
+    document.getElementById('taskDate').value = '2023-08-15';
+
+    createTask();
+
+    expect(tasks.length).toBe(1);
+    expect(tasks[0].repeat).toBe('once');
+    expect(tasks[0].date).toBe('2023-08-15');
   });
 });

--- a/index.html
+++ b/index.html
@@ -62,10 +62,12 @@
             <option value="afternoon">🌞 Afternoon</option>
             <option value="evening">🌙 Evening</option>
           </select>
+          <input id="taskDate" type="date" />
           <select id="taskRepeat">
             <option value="daily">🔁 Daily</option>
             <option value="weekly">🔂 Weekly</option>
             <option value="monthly">📆 Monthly</option>
+            <option value="once">🕑 One Time</option>
           </select>
           <button onclick="createTask()">Add Task</button>
           <button onclick="hideTaskModal()">Cancel</button>

--- a/taskManager.js
+++ b/taskManager.js
@@ -72,16 +72,21 @@ function createTask() {
   const xpEl = document.getElementById("taskXP");
   const repeatEl = document.getElementById("taskRepeat");
   const timeEl = document.getElementById("taskTime");
+  const dateEl = document.getElementById("taskDate");
   if (!nameEl || !xpEl || !repeatEl || !timeEl) return;
 
   const name = nameEl.value.trim();
   const xp = parseInt(xpEl.value.trim(), 10);
   const repeat = repeatEl.value;
   const time = timeEl.value;
+  const date = dateEl ? dateEl.value : '';
   if (!name || isNaN(xp)) return;
 
   const id = Date.now();
   const newTask = { id, text: `${name} • ${formatRepeat(repeat)}`, xp, repeat, time };
+  if (repeat === 'once') {
+    newTask.date = date || new Date().toISOString().split('T')[0];
+  }
   tasks.push(newTask);
   saveTasks();
   if (typeof displayTasks === "function") displayTasks();
@@ -90,6 +95,7 @@ function createTask() {
   xpEl.value = "";
   repeatEl.value = "daily";
   timeEl.value = "morning";
+  if (dateEl) dateEl.value = "";
   const modal = document.getElementById("taskModal");
   if (modal) modal.classList.add("hidden");
 }


### PR DESCRIPTION
## Summary
- allow one-time tasks via new input field and option
- support date for one-time tasks in task manager
- document one-time tasks in README
- test one-time task creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885ae05ab5c832aa1611a44d37ebd1d