### PR TITLE
Add task scheduling with reminders

### DIFF
--- a/__tests__/taskManager.test.js
+++ b/__tests__/taskManager.test.js
@@ -11,6 +11,8 @@ describe('createTask', () => {
         <option value="afternoon">Afternoon</option>
         <option value="evening">Evening</option>
       </select>
+      <input id="taskExactTime" />
+      <input id="taskReminder" type="checkbox" />
       <input id="taskDate" />
       <select id="taskRepeat">
         <option value="daily">Daily</option>
@@ -50,5 +52,19 @@ describe('createTask', () => {
     expect(tasks.length).toBe(1);
     expect(tasks[0].repeat).toBe('once');
     expect(tasks[0].date).toBe('2023-08-15');
+  });
+
+  test('handles exact time and reminder', () => {
+    document.getElementById('taskName').value = 'Timed Task';
+    document.getElementById('taskXP').value = '8';
+    document.getElementById('taskTime').value = 'morning';
+    document.getElementById('taskRepeat').value = 'daily';
+    document.getElementById('taskExactTime').value = '09:30';
+    document.getElementById('taskReminder').checked = true;
+
+    createTask();
+
+    expect(tasks[0].exactTime).toBe('09:30');
+    expect(tasks[0].reminder).toBe(true);
   });
 });

--- a/index.html
+++ b/index.html
@@ -62,6 +62,8 @@
             <option value="afternoon">🌞 Afternoon</option>
             <option value="evening">🌙 Evening</option>
           </select>
+          <input id="taskExactTime" type="time" />
+          <label><input id="taskReminder" type="checkbox" /> Reminder</label>
           <input id="taskDate" type="date" />
           <select id="taskRepeat">
             <option value="daily">🔁 Daily</option>


### PR DESCRIPTION
## Summary
- add specific time and reminder options to tasks
- parse natural language for time input
- show scheduled time in task list
- notify users when a timed task is due
- test handling of specific time creation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885b1bd85fc832aa882cbc3db01507d