### PR TITLE
Add calendar export

### DIFF
--- a/__tests__/calendar.test.js
+++ b/__tests__/calendar.test.js
@@ -1,0 +1,14 @@
+/** @jest-environment jsdom */
+const { tasksToICS } = require('../taskManager.js');
+
+describe('tasksToICS', () => {
+  test('generates ICS for dated task', () => {
+    const tasks = [
+      { id: 1, text: 'Meet NPC • 🕑 One Time', date: '2023-08-15', exactTime: '09:30' }
+    ];
+    const ics = tasksToICS(tasks);
+    expect(ics).toContain('BEGIN:VEVENT');
+    expect(ics).toContain('DTSTART:20230815T093000');
+    expect(ics).toContain('SUMMARY:Meet NPC');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
       <button id="addTaskBtn">➕ Add New Task</button>
       <button id="easyAddBtn">✨ Easy Add</button>
       <button id="generateQuestBtn">🎲 Generate AI Quest</button>
+      <button id="exportCalendarBtn">📅 Export Calendar</button>
       <div id="taskModal" class="modal hidden">
         <div class="modal-box">
           <h3>New Task</h3>

--- a/script.js
+++ b/script.js
@@ -956,6 +956,11 @@ function init() {
     if (txt) TM.createTaskFromText(txt);
   });
 
+  const exportBtn = document.getElementById('exportCalendarBtn');
+  if (exportBtn) exportBtn.addEventListener('click', () => {
+    TM.downloadICS();
+  });
+
 
   // Reset Button
   document.getElementById('resetBtn').onclick = function () {

--- a/taskManager.js
+++ b/taskManager.js
@@ -121,6 +121,40 @@ function createTask() {
   if (modal) modal.classList.add("hidden");
 }
 
+function tasksToICS(taskArray = tasks) {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//MaZi FieryFox//EN'
+  ];
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+  taskArray.forEach(t => {
+    if (!t.date) return;
+    let start = t.date.replace(/-/g, '');
+    if (t.exactTime) start += 'T' + t.exactTime.replace(':', '') + '00';
+    lines.push('BEGIN:VEVENT');
+    lines.push(`UID:${t.id}@mazi-fieryfox`);
+    lines.push(`DTSTAMP:${stamp}`);
+    lines.push(`DTSTART:${start}`);
+    lines.push(`SUMMARY:${t.text.replace(/\s*•.*/, '')}`);
+    lines.push('END:VEVENT');
+  });
+  lines.push('END:VCALENDAR');
+  return lines.join('\r\n');
+}
+
+function downloadICS() {
+  if (typeof document === 'undefined') return;
+  const ics = tasksToICS();
+  const blob = new Blob([ics], { type: 'text/calendar' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'tasks.ics';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 const TaskManager = {
   tasks,
   saveTasks,
@@ -128,7 +162,9 @@ const TaskManager = {
   formatRepeat,
   createTask,
   parseNaturalTask,
-  createTaskFromText
+  createTaskFromText,
+  tasksToICS,
+  downloadICS
 };
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- add calendar export button
- support ICS file generation and download
- wire up export button to download ICS file
- test ICS generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885bc43b0e4832a882f8da8e168743a