### PR TITLE
Add AI quest images

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Some options such as AI quest and story generation use the OpenAI API. Provide y
 
 With an API key set, you can create entirely new companions complete with backstory, personality, a short story hook and a custom quest. Click **Generate AI Character** on the gacha tab to summon one. An image is produced using the DALL·E API and the generated quest is added to your task list automatically.
 With a key set you can:
- - Generate AI quests from the Tasks tab.
- - Generate AI companions from the Gacha tab.
- - Generate an AI story from the Map tab.
+- Generate AI quests from the Tasks tab.
+- Generate AI companions from the Gacha tab.
+- Generate an AI story from the Map tab.
+- AI quests now include a DALL·E image shown beside the task.
 
 

--- a/script.js
+++ b/script.js
@@ -406,6 +406,13 @@ function displayTasks() {
   dueTasks.forEach(t => {
     const div = document.createElement('div');
     div.className = 'task-card' + (completed.includes(t.id) ? ' completed' : '');
+    if (t.imageUrl) {
+      const img = document.createElement('img');
+      img.className = 'task-photo';
+      img.src = t.imageUrl;
+      img.alt = 'quest image';
+      div.appendChild(img);
+    }
     const textSpan = document.createElement('span');
     textSpan.textContent = t.text + (t.exactTime ? ` @ ${t.exactTime}` : '');
     const xpSpan = document.createElement('span');
@@ -604,8 +611,9 @@ async function generateQuestWithAI() {
   const data = await callOpenAI('chat/completions', payload);
   const text = data?.choices?.[0]?.message?.content?.trim();
   if (text) {
+    const imgUrl = await createImage(`illustration of ${text}`);
     const id = Date.now();
-    TM.tasks.push({ id, text, xp: 20 });
+    TM.tasks.push({ id, text, xp: 20, imageUrl: imgUrl });
     TM.saveTasks();
     displayTasks();
   }

--- a/style.css
+++ b/style.css
@@ -110,6 +110,14 @@ body.dark-mode .panel {
   align-items: center;
 }
 
+.task-photo {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-right: 0.5rem;
+}
+
 .task-card.completed {
   background: #d4edda;
   text-decoration: line-through;


### PR DESCRIPTION
## Summary
- display optional task image in task list
- have the AI quest generator create a DALL·E image
- tweak styles for task images
- document that quests now include an image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886cd30ac98832a97609d06e438cb3a