### PR TITLE
Add streak tracking with rewards

### DIFF
--- a/__tests__/streak.test.js
+++ b/__tests__/streak.test.js
@@ -1,0 +1,23 @@
+/** @jest-environment jsdom */
+const { updateStreak } = require('../script');
+
+describe('streak tracking', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    global.alert = jest.fn();
+  });
+
+  test('increments streak and awards xp bonus', () => {
+    localStorage.setItem('mazi_xp', '0');
+    updateStreak();
+    expect(localStorage.getItem('mazi_streak')).toBe('1');
+    expect(localStorage.getItem('mazi_xp')).toBe('5');
+
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    localStorage.setItem('mazi_last_completion_date', yesterday.toDateString());
+    updateStreak();
+    expect(localStorage.getItem('mazi_streak')).toBe('2');
+    expect(localStorage.getItem('mazi_xp')).toBe('15');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <div class="coin-counter">
       <span id="coinCount">120</span> 🪙
     </div>
+    <div class="streak-counter">🔥 Streak: <span id="streakCount">0</span></div>
     <button id="darkModeToggle" class="mode-toggle">🌙 Dark Mode</button>
     <button id="setApiKeyBtn" class="mode-toggle">🔑 API Key</button>
   </header>

--- a/style.css
+++ b/style.css
@@ -85,6 +85,11 @@ button {
   gap: 0.3rem;
 }
 
+.streak-counter {
+  font-weight: bold;
+  margin-left: 0.5rem;
+}
+
 /* Unified Panel Styling */
 .panel {
   background: #fffaf3;


### PR DESCRIPTION
## Summary
- track daily task completion streaks in localStorage
- reward streaks with bonus XP and coins
- display current streak in the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6b1bc3f4832ab0b064f7e2552c42