### PR TITLE
feat: add companion story event system

### DIFF
--- a/eventEngine.js
+++ b/eventEngine.js
@@ -1,0 +1,55 @@
+// eventEngine.js - Logic for unlocking and handling story events
+import { events } from './events.js';
+
+/**
+ * EventEngine manages unlocked/complete events and applies choice effects.
+ */
+export class EventEngine {
+  constructor(storageKey = 'completedEvents') {
+    this.events = events;
+    this.storageKey = storageKey;
+    this.completed = this.loadCompleted();
+  }
+
+  // Load completion data from localStorage
+  loadCompleted() {
+    try {
+      return JSON.parse(localStorage.getItem(this.storageKey)) || {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  // Persist completion data
+  saveCompleted() {
+    localStorage.setItem(this.storageKey, JSON.stringify(this.completed));
+  }
+
+  // Retrieve all unlocked events for a companion based on relationship level
+  getUnlockedEvents(companionId, level) {
+    const all = this.events[companionId] || [];
+    return all.filter(evt => evt.unlockLevel <= level);
+  }
+
+  // Check if a specific event has been completed
+  isEventCompleted(companionId, eventId) {
+    return (this.completed[companionId] || []).includes(eventId);
+  }
+
+  // Mark event as completed
+  completeEvent(companionId, eventId) {
+    if (!this.completed[companionId]) this.completed[companionId] = [];
+    if (!this.completed[companionId].includes(eventId)) {
+      this.completed[companionId].push(eventId);
+      this.saveCompleted();
+    }
+  }
+
+  // Apply a choice effect (simple affection update parser)
+  applyChoiceEffect(companion, effect) {
+    const match = /affection([+-]\d+)/.exec(effect);
+    if (match) {
+      companion.affection = (companion.affection || 0) + parseInt(match[1], 10);
+    }
+  }
+}

--- a/eventUI.js
+++ b/eventUI.js
@@ -1,0 +1,111 @@
+// eventUI.js - Handles DOM interactions for story events
+import { EventEngine } from './eventEngine.js';
+
+// Sample companion data for demo purposes
+const companion = {
+  id: 'ayla',
+  name: 'Ayla',
+  relationshipLevel: 3,
+  affection: 0
+};
+
+// Initialize engine
+const engine = new EventEngine();
+
+// --------- UI Elements ---------
+const openViewerBtn = document.getElementById('openEventViewerBtn');
+const eventListModal = document.getElementById('eventListModal');
+const eventList = document.getElementById('eventList');
+const closeEventListBtn = document.getElementById('closeEventListBtn');
+
+const storyEventModal = document.getElementById('storyEventModal');
+const eventBackground = document.getElementById('eventBackground');
+const eventPortrait = document.getElementById('eventPortrait');
+const eventDialogue = document.getElementById('eventDialogue');
+const eventChoices = document.getElementById('eventChoices');
+const nextDialogueBtn = document.getElementById('nextDialogueBtn');
+
+// Utility: generate placeholder image URL based on prompt
+function generateAIImage(prompt) {
+  return `https://placehold.co/800x600?text=${encodeURIComponent(prompt)}`;
+}
+
+// Open event list modal showing unlocked events
+openViewerBtn?.addEventListener('click', () => {
+  renderEventList();
+  eventListModal.classList.remove('hidden');
+});
+closeEventListBtn?.addEventListener('click', () => {
+  eventListModal.classList.add('hidden');
+});
+
+// Render list of unlocked events
+function renderEventList() {
+  eventList.innerHTML = '';
+  const unlocked = engine.getUnlockedEvents(companion.id, companion.relationshipLevel);
+  unlocked.forEach(evt => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.textContent = evt.title + (engine.isEventCompleted(companion.id, evt.id) ? ' ✓' : '');
+    btn.addEventListener('click', () => {
+      eventListModal.classList.add('hidden');
+      playEvent(evt);
+    });
+    li.appendChild(btn);
+    eventList.appendChild(li);
+  });
+}
+
+// Play through an event's dialogue and choices
+function playEvent(evt) {
+  // Generate images
+  eventBackground.src = generateAIImage(evt.backgroundPrompt);
+  eventPortrait.src = generateAIImage(evt.imagePrompt);
+
+  let dialogueIndex = 0;
+  eventDialogue.textContent = '';
+  eventChoices.innerHTML = '';
+  nextDialogueBtn.classList.remove('hidden');
+
+  function showNextLine() {
+    if (dialogueIndex < evt.dialogue.length) {
+      typeLine(evt.dialogue[dialogueIndex], eventDialogue, () => {
+        dialogueIndex++;
+      });
+    } else {
+      nextDialogueBtn.classList.add('hidden');
+      showChoices();
+    }
+  }
+
+  nextDialogueBtn.onclick = showNextLine;
+  showNextLine();
+  storyEventModal.classList.remove('hidden');
+
+  function showChoices() {
+    evt.choices.forEach(choice => {
+      const btn = document.createElement('button');
+      btn.textContent = choice.text;
+      btn.addEventListener('click', () => {
+        engine.applyChoiceEffect(companion, choice.effect);
+        engine.completeEvent(companion.id, evt.id);
+        storyEventModal.classList.add('hidden');
+      });
+      eventChoices.appendChild(btn);
+    });
+  }
+}
+
+// Simple typewriter animation
+function typeLine(text, element, callback) {
+  element.textContent = '';
+  let i = 0;
+  const interval = setInterval(() => {
+    element.textContent += text.charAt(i);
+    i++;
+    if (i >= text.length) {
+      clearInterval(interval);
+      callback();
+    }
+  }, 40);
+}

--- a/events.js
+++ b/events.js
@@ -1,0 +1,36 @@
+// events.js - Sample companion story events
+// Each companion ID maps to an array of milestone-based events.
+export const events = {
+  ayla: [
+    {
+      id: 'ayla-1',
+      unlockLevel: 1,
+      title: 'First Meeting',
+      backgroundPrompt: 'sunny meadow with flowers',
+      imagePrompt: 'friendly archer girl named Ayla smiling',
+      dialogue: [
+        'You finally showed up!',
+        'Ready for an adventure together?'
+      ],
+      choices: [
+        { text: 'Absolutely!', effect: 'affection+10' },
+        { text: 'Maybe later...', effect: 'affection-5' }
+      ]
+    },
+    {
+      id: 'ayla-2',
+      unlockLevel: 3,
+      title: 'Under the Moon',
+      backgroundPrompt: 'quiet forest clearing at night, moonlight',
+      imagePrompt: 'ayla looking thoughtful under the moon',
+      dialogue: [
+        'The night is calm. It reminds me of my home.',
+        'Thanks for being here with me.'
+      ],
+      choices: [
+        { text: 'Anytime, Ayla.', effect: 'affection+15' },
+        { text: 'It is getting late.', effect: 'affection-5' }
+      ]
+    }
+  ]
+};

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
     <section id="companions-section" class="main-section panel">
       <h2>Your Companions</h2>
       <div class="companion-list"></div>
+      <button id="openEventViewerBtn">📖 Story Events</button>
       <div id="companionModal" class="modal hidden">
         <div class="modal-box">
           <img id="cardImg" src="" alt="portrait" class="card-img" />
@@ -171,5 +172,27 @@
       <button onclick="closeBondModal()">💗 Respond</button>
     </div>
   </div>
+
+  <!-- STORY EVENT MODALS -->
+  <div id="eventListModal" class="modal hidden">
+    <div class="modal-box">
+      <h3>Story Events</h3>
+      <ul id="eventList"></ul>
+      <button id="closeEventListBtn">Close</button>
+    </div>
+  </div>
+
+  <div id="storyEventModal" class="modal hidden">
+    <div class="story-modal-content">
+      <img id="eventBackground" class="event-background" />
+      <img id="eventPortrait" class="event-portrait" />
+      <div id="eventDialogue" class="event-dialogue"></div>
+      <div id="eventChoices" class="event-choices"></div>
+      <button id="nextDialogueBtn" class="hidden">Next</button>
+    </div>
+  </div>
+
+  <!-- STORY EVENT SCRIPTS -->
+  <script type="module" src="eventUI.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -536,3 +536,64 @@ body.dark-mode .character-card {
   background: #2c2c2c;
   color: #eee;
 }
+
+/* Story Event System */
+#storyEventModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+#storyEventModal .story-modal-content {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.event-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.event-portrait {
+  position: absolute;
+  bottom: 0;
+  right: 10%;
+  width: 30%;
+}
+
+.event-dialogue {
+  position: absolute;
+  bottom: 20%;
+  left: 5%;
+  right: 5%;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.event-choices {
+  position: absolute;
+  bottom: 5%;
+  left: 5%;
+  right: 5%;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+#eventListModal ul {
+  list-style: none;
+  padding: 0;
+}
+
+#eventListModal li {
+  margin: 0.5rem 0;
+}


### PR DESCRIPTION
## Summary
- add sample milestone-based events for companions
- implement engine for unlocking, tracking, and applying choice effects
- create UI to play story cutscenes with typewriter dialogue and choices
- integrate event viewer and styling into existing app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d6c947d10832ab147a4a5540581d7