### PR TITLE
feat: add companion dialogue system

### DIFF
--- a/companions.js
+++ b/companions.js
@@ -1,0 +1,49 @@
+export const companions = {
+  selene: {
+    id: 'selene',
+    name: 'Selene Graytail',
+    personality: 'playful fox spirit who loves moonlit strolls',
+    relationshipLevel: 3,
+    recentEvents: ['gifted a silver pendant'],
+    mood: 'cheerful'
+  },
+  nyx: {
+    id: 'nyx',
+    name: 'Nyx Shadowtail',
+    personality: 'brooding rogue with a soft spot for humor',
+    relationshipLevel: 2,
+    recentEvents: ['completed a stealth mission together'],
+    mood: 'mischievous'
+  },
+  lilith: {
+    id: 'lilith',
+    name: 'Lilith Flamesworn',
+    personality: 'fiery mage who respects strength',
+    relationshipLevel: 1,
+    recentEvents: [],
+    mood: 'irritable'
+  },
+  felina: {
+    id: 'felina',
+    name: 'Felina Moonshade',
+    personality: 'quiet healer with a caring heart',
+    relationshipLevel: 4,
+    recentEvents: ['shared a quiet evening watching the stars'],
+    mood: 'serene'
+  }
+};
+
+export function getCompanion(id) {
+  return companions[id] || null;
+}
+
+export function updateMood(id, mood) {
+  if (companions[id]) companions[id].mood = mood;
+}
+
+export function addRecentEvent(id, event) {
+  if (!companions[id]) return;
+  const events = companions[id].recentEvents;
+  events.unshift(event);
+  if (events.length > 3) events.pop();
+}

--- a/dialogueEngine.js
+++ b/dialogueEngine.js
@@ -1,0 +1,50 @@
+import { getCompanion } from './companions.js';
+
+export function buildSystemPrompt(id) {
+  const comp = getCompanion(id);
+  if (!comp) return 'You are a mysterious companion.';
+  const { name, personality, relationshipLevel, recentEvents, mood } = comp;
+  const eventsText = recentEvents && recentEvents.length ? recentEvents.join(', ') : 'no notable recent events';
+  return `You are ${name}, ${personality}. Your relationship level with the player is ${relationshipLevel}. Recent events: ${eventsText}. You currently feel ${mood}. Stay in character and keep replies brief.`;
+}
+
+export async function fetchAIResponse(id, playerInput) {
+  const systemPrompt = buildSystemPrompt(id);
+  const apiKey = localStorage.getItem('openaiKey');
+  if (!apiKey) {
+    return mockResponse(id);
+  }
+  const payload = {
+    model: 'gpt-3.5-turbo',
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: playerInput }
+    ],
+    max_tokens: 60
+  };
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    return data?.choices?.[0]?.message?.content?.trim() || '';
+  } catch (err) {
+    console.error('AI call failed', err);
+    return mockResponse(id);
+  }
+}
+
+function mockResponse(id) {
+  const comp = getCompanion(id) || { name: 'The companion', mood: 'calm' };
+  const replies = [
+    `${comp.name} smiles softly. "It's a fine day to chat, isn't it?"`,
+    `"I have been feeling quite ${comp.mood} today."`,
+    `"Our adventures make for good stories."`
+  ];
+  return replies[Math.floor(Math.random() * replies.length)];
+}

--- a/dialogueUI.js
+++ b/dialogueUI.js
@@ -1,0 +1,87 @@
+import { getCompanion } from './companions.js';
+import { fetchAIResponse } from './dialogueEngine.js';
+
+const modal = document.getElementById('dialogueModal');
+const historyEl = document.getElementById('dialogueHistory');
+const nameEl = document.getElementById('dialogueCompanionName');
+const textArea = document.getElementById('playerMessage');
+const promptsEl = document.getElementById('promptButtons');
+const sendBtn = document.getElementById('sendDialogueBtn');
+const closeBtn = document.getElementById('closeDialogueBtn');
+
+const PROMPTS = [
+  'Ask about her past',
+  'Say something flirty',
+  'Invite her on an adventure'
+];
+
+let currentId = null;
+let history = [];
+
+function renderPrompts() {
+  promptsEl.innerHTML = '';
+  PROMPTS.forEach(p => {
+    const btn = document.createElement('button');
+    btn.className = 'prompt-btn';
+    btn.textContent = p;
+    btn.addEventListener('click', () => {
+      sendMessage(p);
+    });
+    promptsEl.appendChild(btn);
+  });
+}
+
+function loadHistory(id) {
+  return JSON.parse(localStorage.getItem(`dialogue_history_${id}`) || '[]');
+}
+
+function saveHistory(id) {
+  localStorage.setItem(`dialogue_history_${id}`, JSON.stringify(history.slice(-5)));
+}
+
+function renderHistory() {
+  historyEl.innerHTML = '';
+  const comp = getCompanion(currentId);
+  history.forEach(pair => {
+    const p1 = document.createElement('p');
+    p1.textContent = `You: ${pair.player}`;
+    historyEl.appendChild(p1);
+    const p2 = document.createElement('p');
+    p2.textContent = `${comp.name}: ${pair.ai}`;
+    historyEl.appendChild(p2);
+  });
+}
+
+async function sendMessage(msg) {
+  if (!msg || !currentId) return;
+  const reply = await fetchAIResponse(currentId, msg);
+  history.push({ player: msg, ai: reply });
+  if (history.length > 5) history.shift();
+  saveHistory(currentId);
+  renderHistory();
+}
+
+export function openDialogueModal(id) {
+  const comp = getCompanion(id);
+  if (!comp) return;
+  currentId = id;
+  nameEl.textContent = comp.name;
+  history = loadHistory(id);
+  renderPrompts();
+  renderHistory();
+  modal.classList.remove('hidden');
+}
+
+function closeDialogueModal() {
+  modal.classList.add('hidden');
+}
+
+sendBtn.addEventListener('click', () => {
+  const msg = textArea.value.trim();
+  textArea.value = '';
+  sendMessage(msg);
+});
+
+closeBtn.addEventListener('click', closeDialogueModal);
+
+window.openDialogueModal = openDialogueModal;

--- a/index.html
+++ b/index.html
@@ -118,6 +118,16 @@
           <button onclick="hideCard()">Close</button>
         </div>
       </div>
+      <div id="dialogueModal" class="modal hidden">
+        <div class="modal-box">
+          <h3 id="dialogueCompanionName"></h3>
+          <div id="dialogueHistory" class="dialogue-history"></div>
+          <textarea id="playerMessage" rows="3" placeholder="Say something..."></textarea>
+          <div id="promptButtons" class="prompt-buttons"></div>
+          <button id="sendDialogueBtn">Send</button>
+          <button id="closeDialogueBtn">Close</button>
+        </div>
+      </div>
     </section>
 
     <!-- GACHA TAB -->
@@ -195,5 +205,6 @@
 
   <!-- STORY EVENT SCRIPTS -->
   <script type="module" src="eventUI.js"></script>
+  <script type="module" src="dialogueUI.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -274,6 +274,7 @@ function displayCompanionsUI() {
 
         const card = document.createElement('div');
         card.className = `companion-card ${rarity}`;
+        const id = name.toLowerCase().split(' ')[0];
         card.innerHTML = `
           <div class="companion-avatar" style="background-image: url('${imgUrl}');"></div>
           <div>
@@ -281,11 +282,21 @@ function displayCompanionsUI() {
             <div style="margin: 0.25em 0 0.3em 0">${stars}</div>
             <span class="rarity-badge">${rarity ? '★ ' + comp.Rarity : ''}</span>
             <div class="bond-level">Bond Lv ${bondLevel}</div>
+            <button class="talk-btn" data-companion="${id}">Talk</button>
           </div>
         `;
         card.addEventListener('click', () => {
           showCardFromData(comp, starCount);
         });
+        const talkBtn = card.querySelector('.talk-btn');
+        if (talkBtn) {
+          talkBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            if (window.openDialogueModal) {
+              window.openDialogueModal(id);
+            }
+          });
+        }
 
         list.appendChild(card);
       }

--- a/style.css
+++ b/style.css
@@ -214,6 +214,26 @@ body.dark-mode .panel {
   color: #c47932;
   font-weight: bold;
 }
+.talk-btn {
+  margin-top: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.8rem;
+}
+.dialogue-history {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+}
+.prompt-buttons {
+  margin: 0.5rem 0;
+  display: flex;
+  gap: 0.5rem;
+}
+.prompt-btn {
+  flex: 1;
+  padding: 0.4rem;
+  font-size: 0.8rem;
+}
 
 /* Modal Styling (consolidated) */
 .modal {


### PR DESCRIPTION
## Summary
- add companion dialogue data module
- implement dialogue engine with dynamic system prompt
- create UI modal for chatting with companions and storing history
- add Talk buttons to companion cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d6ef0c0c4832abfeb746144283201