### PR TITLE
feat: persist AI story progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ With a key set you can:
 - Generate AI quests from the Tasks tab.
 - Generate AI companions from the Gacha tab.
 - Generate an AI story from the Map tab.
+- AI stories now persist in local storage so you can continue them across sessions.
 - AI quests now include a DALL·E image shown beside the task.
 
 

--- a/adventure.js
+++ b/adventure.js
@@ -38,7 +38,33 @@ let currentNode = 'start';
 let playerHP = 10;
 let enemyHP = 0;
 let nextAfterCombat = null;
-let storyHistory = [];
+function loadStoryHistory() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem('ai_story_history') || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function saveStoryHistory() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem('ai_story_history', JSON.stringify(storyHistory));
+}
+
+let storyHistory = loadStoryHistory();
+
+function renderStoredStory() {
+  const storyEl = document.getElementById('storyText');
+  const inputBox = document.getElementById('storyInputBox');
+  if (!storyEl || !inputBox || storyHistory.length === 0) return;
+  storyEl.innerHTML = storyHistory
+    .filter(m => m.role === 'assistant')
+    .map(m => `<p>${m.content}</p>`)
+    .join('');
+  inputBox.classList.remove('hidden');
+  storyEl.scrollTop = storyEl.scrollHeight;
+}
 
 function showNode(id) {
   currentNode = id;
@@ -104,6 +130,7 @@ function startCombat(info) {
 
 function startAdventure() {
   storyHistory = [];
+  saveStoryHistory();
   const inputBox = document.getElementById('storyInputBox');
   if (inputBox) inputBox.classList.add('hidden');
   playerHP = 10;
@@ -128,6 +155,7 @@ async function generateStoryWithAI() {
     if (storyEl) storyEl.innerHTML = `<p>${text}</p>`;
     if (choiceEl) choiceEl.innerHTML = '';
     if (inputBox) inputBox.classList.remove('hidden');
+    saveStoryHistory();
   }
 }
 
@@ -148,10 +176,12 @@ async function continueAIStory() {
     p.textContent = text;
     storyEl.appendChild(p);
     storyEl.scrollTop = storyEl.scrollHeight;
+    saveStoryHistory();
   }
 }
 
 if (typeof window !== 'undefined') {
+  renderStoredStory();
   window.startAdventure = startAdventure;
   window.generateStoryWithAI = generateStoryWithAI;
   window.continueAIStory = continueAIStory;


### PR DESCRIPTION
## Summary
- store AI story history in localStorage and reload on startup
- update AI story functions to save progress and resume automatically
- document persistent AI stories in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d715b6bec832abf78de926d51b132