### PR TITLE
Add companion evolution system with UI

### DIFF
--- a/evolutionData.js
+++ b/evolutionData.js
@@ -1,0 +1,23 @@
+export const evolutionData = {
+  selene: [
+    { title: 'Wandering Cub', minLevel: 1, image: 'images/selene_1.png' },
+    { title: 'Moonlit Vixen', minLevel: 3, image: 'images/selene_2.png', aura: 'aura-moon' },
+    { title: 'Celestial Kitsune', minLevel: 5, image: 'images/selene_3.png', aura: 'aura-celestial', bonus: 'lunarBlessing' }
+  ],
+  nyx: [
+    { title: 'Shadow Pup', minLevel: 1, image: 'images/nyx_1.png' },
+    { title: 'Night Stalker', minLevel: 4, image: 'images/nyx_2.png', aura: 'aura-shadow', bonus: 'stealthStep' }
+  ],
+  lilith: [
+    { title: 'Cinder Kit', minLevel: 1, image: 'images/lilith_1.png' },
+    { title: 'Flame Weaver', minLevel: 3, image: 'images/lilith_2.png', aura: 'aura-fire' }
+  ],
+  felina: [
+    { title: 'Quiet Kit', minLevel: 1, image: 'images/felina_1.png' },
+    { title: 'Star Healer', minLevel: 4, image: 'images/felina_2.png', aura: 'aura-starlight', bonus: 'healingPulse' }
+  ]
+};
+
+if (typeof module !== 'undefined') {
+  module.exports = { evolutionData };
+}

--- a/evolutionEngine.js
+++ b/evolutionEngine.js
@@ -1,0 +1,71 @@
+import { evolutionData } from './evolutionData.js';
+import { showEvolutionSequence } from './evolutionUI.js';
+
+const STORAGE_KEY = 'mazi_companion_forms';
+
+function loadFormState() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function saveFormState(state) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+export function getCurrentForm(companionId) {
+  const state = loadFormState();
+  return state[companionId] || 0;
+}
+
+export function setCurrentForm(companionId, index) {
+  const state = loadFormState();
+  state[companionId] = index;
+  saveFormState(state);
+}
+
+export function applyStoredForm(companion) {
+  const forms = evolutionData[companion.id];
+  if (!forms) return;
+  const idx = getCurrentForm(companion.id);
+  const form = forms[idx];
+  if (form) {
+    companion.title = form.title;
+    companion.image = form.image;
+    if (form.bonus) companion.bonus = form.bonus;
+  }
+}
+
+function evolve(companion, form, nextIndex) {
+  setCurrentForm(companion.id, nextIndex);
+  companion.title = form.title;
+  companion.image = form.image;
+  if (form.bonus) companion.bonus = form.bonus;
+  showEvolutionSequence(companion, form);
+}
+
+export function checkForEvolution(companion) {
+  const forms = evolutionData[companion.id];
+  if (!forms) return false;
+  const currentIndex = getCurrentForm(companion.id);
+  const nextForm = forms[currentIndex + 1];
+  if (!nextForm) return false;
+  if ((companion.relationshipLevel || 0) >= nextForm.minLevel) {
+    evolve(companion, nextForm, currentIndex + 1);
+    return true;
+  }
+  return false;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    loadFormState,
+    saveFormState,
+    getCurrentForm,
+    setCurrentForm,
+    applyStoredForm,
+    checkForEvolution
+  };
+}

--- a/evolutionUI.js
+++ b/evolutionUI.js
@@ -1,0 +1,84 @@
+// Handles animations, overlays, and cutscene triggers for evolutions
+
+function ensureModal() {
+  if (typeof document === 'undefined') return null;
+  let modal = document.getElementById('evolutionModal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'evolutionModal';
+    modal.className = 'modal hidden';
+    modal.innerHTML = `
+      <div class="modal-box evolution-box">
+        <img id="evolutionImage" class="evolution-img" />
+        <h3 id="evolutionTitle"></h3>
+        <p id="evolutionBonus" class="evolution-bonus"></p>
+      </div>`;
+    document.body.appendChild(modal);
+
+    const style = document.createElement('style');
+    style.textContent = `
+      .evolution-img { max-width: 100%; }
+      .evolution-box { text-align: center; }
+      .evolution-anim { animation: evoFlash 1s ease-in-out; }
+      @keyframes evoFlash { from { opacity: 0; transform: scale(0.8); } to { opacity: 1; transform: scale(1); } }
+    `;
+    document.head.appendChild(style);
+  }
+  return modal;
+}
+
+export function showEvolutionSequence(companion, form) {
+  const modal = ensureModal();
+  if (!modal) return;
+  const img = modal.querySelector('#evolutionImage');
+  const title = modal.querySelector('#evolutionTitle');
+  const bonus = modal.querySelector('#evolutionBonus');
+
+  img.src = form.image;
+  title.textContent = `${companion.name} evolved into ${form.title}!`;
+  if (form.bonus) {
+    bonus.textContent = `Unlocked: ${form.bonus}`;
+    bonus.style.display = 'block';
+  } else {
+    bonus.textContent = '';
+    bonus.style.display = 'none';
+  }
+
+  img.classList.add('evolution-anim');
+  setTimeout(() => img.classList.remove('evolution-anim'), 1000);
+
+  modal.classList.remove('hidden');
+  modal.addEventListener('click', hideModal);
+
+  updateCardDisplay(companion, form);
+}
+
+function hideModal() {
+  const modal = document.getElementById('evolutionModal');
+  if (!modal) return;
+  modal.classList.add('hidden');
+  modal.removeEventListener('click', hideModal);
+}
+
+function updateCardDisplay(companion, form) {
+  if (typeof document === 'undefined') return;
+  const cardModal = document.getElementById('companionModal');
+  const cardName = document.getElementById('cardName');
+  if (cardModal && !cardModal.classList.contains('hidden') && cardName && cardName.textContent === companion.name) {
+    const img = document.getElementById('cardImg');
+    const title = document.getElementById('cardTitle');
+    if (img) {
+      img.src = form.image;
+      if (form.aura) img.classList.add(form.aura); else img.classList.remove(form.aura);
+    }
+    if (title) title.textContent = form.title;
+  }
+  // Refresh companion list if available
+  if (typeof window !== 'undefined' && typeof window.displayCompanionsUI === 'function') {
+    window.displayCompanionsUI();
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { showEvolutionSequence };
+}


### PR DESCRIPTION
## Summary
- add evolutionData.js to define companion evolution forms
- create evolutionEngine.js to track forms in localStorage and check for upgrades
- implement evolutionUI.js to show evolution animations and refresh companion cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d79be0ba4832a85ea85e3e8177c5b