### PR TITLE
feat: add fantasy quest log

### DIFF
--- a/aiTasks.js
+++ b/aiTasks.js
@@ -1,0 +1,39 @@
+export function generateQuest() {
+  const today = new Date().toISOString().split('T')[0];
+  const quests = [
+    {
+      title: 'The Hydration Trial',
+      description: 'Drink 64oz of water today to replenish your inner wellspring.',
+      priority: 'medium',
+      category: 'health',
+      dueDate: today,
+      isRecurring: false
+    },
+    {
+      title: 'Meditation of the Mindforge',
+      description: 'Spend 10 minutes in stillness to sharpen your mental blade.',
+      priority: 'low',
+      category: 'discipline',
+      dueDate: today,
+      isRecurring: true,
+      recurrence: 'daily'
+    },
+    {
+      title: 'The Trial of Focus',
+      description: 'Work uninterrupted on a single task for 25 minutes.',
+      priority: 'high',
+      category: 'productivity',
+      dueDate: today,
+      isRecurring: false
+    },
+    {
+      title: 'Bond of the Hearth',
+      description: 'Send a heartfelt message to a loved one.',
+      priority: 'medium',
+      category: 'relationship',
+      dueDate: today,
+      isRecurring: false
+    }
+  ];
+  return quests[Math.floor(Math.random() * quests.length)];
+}

--- a/index.html
+++ b/index.html
@@ -49,36 +49,70 @@
       </div>
     </section>
 
-    <!-- TASKS TAB -->
+    <!-- TASKS TAB / QUEST LOG -->
     <section id="tasks-section" class="main-section panel">
-      <h2>Daily Quests</h2>
-      <p id="taskMilestoneDisplay">Tasks Completed: <span id="taskMilestone">0</span></p>
-      <div id="taskList" class="task-category"></div>
-      <button id="addTaskBtn">➕ Add New Task</button>
-      <button id="easyAddBtn">✨ Easy Add</button>
-      <button id="generateQuestBtn">🎲 Generate AI Quest</button>
-      <button id="exportCalendarBtn">📅 Export Calendar</button>
-      <div id="taskModal" class="modal hidden">
+      <h2>Quest Log</h2>
+      <div class="quest-controls">
+        <button id="addQuestBtn">➕ New Quest</button>
+        <button id="aiQuestBtn">🎲 Generate Quest</button>
+        <div id="categoryFilters" class="category-filters"></div>
+      </div>
+
+      <div class="quest-rewards">
+        <span id="questXP">0 XP</span>
+        <span id="questCoins">0 🪙</span>
+      </div>
+
+      <div id="questList" class="quest-list"></div>
+
+      <h3>Completed Quests</h3>
+      <div id="completedList" class="quest-list completed"></div>
+
+      <!-- Quest Modal -->
+      <div id="questModal" class="modal hidden">
         <div class="modal-box">
-          <h3>New Task</h3>
-          <input id="taskName" type="text" placeholder="Task name" />
-          <input id="taskXP" type="number" placeholder="XP amount" />
-          <select id="taskTime">
-            <option value="morning">🌅 Morning</option>
-            <option value="afternoon">🌞 Afternoon</option>
-            <option value="evening">🌙 Evening</option>
-          </select>
-          <input id="taskExactTime" type="time" />
-          <label><input id="taskReminder" type="checkbox" /> Reminder</label>
-          <input id="taskDate" type="date" />
-          <select id="taskRepeat">
-            <option value="daily">🔁 Daily</option>
-            <option value="weekly">🔂 Weekly</option>
-            <option value="monthly">📆 Monthly</option>
-            <option value="once">🕑 One Time</option>
-          </select>
-          <button onclick="createTask()">Add Task</button>
-          <button onclick="hideTaskModal()">Cancel</button>
+          <h3 id="modalTitle">New Quest</h3>
+          <form id="questForm">
+            <input id="questTitle" type="text" placeholder="Title" required />
+            <textarea id="questDesc" placeholder="Description"></textarea>
+
+            <label>Priority
+              <select id="questPriority">
+                <option value="high">High</option>
+                <option value="medium">Medium</option>
+                <option value="low">Low</option>
+              </select>
+            </label>
+
+            <label>Category
+              <select id="questCategory">
+                <option value="health">Health</option>
+                <option value="productivity">Productivity</option>
+                <option value="relationship">Relationship</option>
+                <option value="discipline">Discipline</option>
+              </select>
+            </label>
+
+            <label>Due Date <input id="questDue" type="date" /></label>
+
+            <label><input id="questRecurring" type="checkbox" /> Recurring</label>
+            <select id="questRecurrence" class="hidden">
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+            </select>
+
+            <label>Companion
+              <select id="questCompanion">
+                <option value="">None</option>
+              </select>
+            </label>
+
+            <div class="modal-buttons">
+              <button type="submit">Save</button>
+              <button type="button" id="cancelQuestBtn">Cancel</button>
+            </div>
+          </form>
         </div>
       </div>
     </section>
@@ -173,6 +207,7 @@
   <script src="taskManager.js"></script>
   <script src="script.js"></script>
   <script src="adventure.js"></script>
+  <script type="module" src="taskUI.js"></script>
 
   <!-- BOND EVENT MODAL -->
   <div id="bondEventModal" class="modal hidden">

--- a/script.js
+++ b/script.js
@@ -1052,7 +1052,8 @@ function init() {
   if (closeBtn) closeBtn.addEventListener('click', closeChat);
 
   // Add Task Button
-  document.getElementById("addTaskBtn").addEventListener("click", () => {
+  const addTaskBtn = document.getElementById("addTaskBtn");
+  if (addTaskBtn) addTaskBtn.addEventListener("click", () => {
     document.getElementById("taskModal").classList.remove("hidden");
   });
 

--- a/style.css
+++ b/style.css
@@ -628,3 +628,90 @@ body.dark-mode .character-card {
 #eventListModal li {
   margin: 0.5rem 0;
 }
+
+/* Quest Log Styles */
+#tasks-section {
+  background: #f8f1e9 url('images/parchment_bg.jpg');
+  background-size: cover;
+}
+.quest-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.category-filters button {
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent-color);
+  cursor: pointer;
+}
+.category-filters button.active {
+  background: var(--accent-dark);
+  color: #fff;
+}
+.quest-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.quest-card {
+  background: #fffaf0;
+  border: 1px solid #e0d8c3;
+  border-radius: 8px;
+  padding: 0.8rem;
+  position: relative;
+  overflow: hidden;
+}
+.quest-card.completed {
+  text-decoration: line-through;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+.badge {
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+.priority-high {
+  background: #c0392b;
+}
+.priority-medium {
+  background: #f39c12;
+}
+.priority-low {
+  background: #27ae60;
+}
+.complete-btn {
+  background: var(--accent-color);
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+.quest-rewards {
+  margin: 0.5rem 0;
+  display: flex;
+  gap: 1rem;
+  font-weight: bold;
+}
+.particle {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  background: var(--accent-color);
+  border-radius: 50%;
+  pointer-events: none;
+  animation: particle 600ms ease-out forwards;
+}
+@keyframes particle {
+  from { opacity: 1; transform: translate(0,0) scale(1); }
+  to { opacity: 0; transform: translate(var(--x), var(--y)) scale(0); }
+}
+.typewriter {
+  font-family: 'Courier New', monospace;
+}

--- a/taskData.js
+++ b/taskData.js
@@ -1,0 +1,37 @@
+export const TASKS_KEY = 'quest_tasks';
+export const tasks = [];
+
+export function loadTasks() {
+  if (typeof localStorage === 'undefined') return;
+  const raw = localStorage.getItem(TASKS_KEY);
+  const data = raw ? JSON.parse(raw) : [];
+  tasks.splice(0, tasks.length, ...data);
+}
+
+export function saveTasks() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(TASKS_KEY, JSON.stringify(tasks));
+}
+
+export function createTask(data) {
+  const rewardTable = {
+    high: { xp: 30, coins: 3 },
+    medium: { xp: 20, coins: 2 },
+    low: { xp: 10, coins: 1 }
+  };
+  const rewards = rewardTable[data.priority] || rewardTable.low;
+  return {
+    id: Date.now(),
+    title: data.title,
+    description: data.description || '',
+    priority: data.priority || 'low',
+    category: data.category || 'general',
+    dueDate: data.dueDate || '',
+    completed: false,
+    isRecurring: data.isRecurring || false,
+    recurrence: data.recurrence || null,
+    companionId: data.companionId || '',
+    xp: rewards.xp,
+    coins: rewards.coins
+  };
+}

--- a/taskEngine.js
+++ b/taskEngine.js
@@ -1,0 +1,50 @@
+import { tasks, saveTasks, createTask } from './taskData.js';
+import { addRecentEvent } from './companions.js';
+
+export function addTask(data) {
+  const task = createTask(data);
+  tasks.push(task);
+  saveTasks();
+  return task;
+}
+
+export function completeTask(id) {
+  const task = tasks.find(t => t.id === id);
+  if (!task) return null;
+  if (task.isRecurring && task.recurrence) {
+    const d = task.dueDate ? new Date(task.dueDate) : new Date();
+    if (task.recurrence === 'daily') d.setDate(d.getDate() + 1);
+    else if (task.recurrence === 'weekly') d.setDate(d.getDate() + 7);
+    else if (task.recurrence === 'monthly') d.setMonth(d.getMonth() + 1);
+    task.dueDate = d.toISOString().split('T')[0];
+  } else {
+    task.completed = true;
+    if (task.companionId) {
+      addRecentEvent(task.companionId, `Guided you through "${task.title}"`);
+    }
+  }
+  saveTasks();
+  return task;
+}
+
+export function assignCompanion(id, companionId) {
+  const task = tasks.find(t => t.id === id);
+  if (!task) return;
+  task.companionId = companionId;
+  saveTasks();
+}
+
+export function getActiveTasks(category = 'all') {
+  let list = tasks.filter(t => !t.completed);
+  if (category !== 'all') list = list.filter(t => t.category === category);
+  return sortTasks(list);
+}
+
+export function getCompletedTasks() {
+  return tasks.filter(t => t.completed);
+}
+
+export function sortTasks(list) {
+  const order = { high: 0, medium: 1, low: 2 };
+  return list.sort((a, b) => order[a.priority] - order[b.priority]);
+}

--- a/taskUI.js
+++ b/taskUI.js
@@ -1,0 +1,207 @@
+import { tasks, loadTasks } from './taskData.js';
+import { addTask, completeTask, getActiveTasks, getCompletedTasks } from './taskEngine.js';
+import { generateQuest } from './aiTasks.js';
+import { companions } from './companions.js';
+
+let currentCategory = 'all';
+
+function init() {
+  if (typeof document === 'undefined') return;
+  loadTasks();
+  populateCompanionOptions();
+  initFilters();
+  render();
+
+  document.getElementById('addQuestBtn').addEventListener('click', () => openModal());
+  document.getElementById('aiQuestBtn').addEventListener('click', () => {
+    const q = generateQuest();
+    openModal(q);
+  });
+  document.getElementById('cancelQuestBtn').addEventListener('click', closeModal);
+  document.getElementById('questForm').addEventListener('submit', saveQuest);
+  document.getElementById('questRecurring').addEventListener('change', e => {
+    document.getElementById('questRecurrence').classList.toggle('hidden', !e.target.checked);
+  });
+  updateRewardDisplay();
+}
+
+document.addEventListener('DOMContentLoaded', init);
+
+function populateCompanionOptions() {
+  const select = document.getElementById('questCompanion');
+  Object.values(companions).forEach(c => {
+    const opt = document.createElement('option');
+    opt.value = c.id;
+    opt.textContent = c.name;
+    select.appendChild(opt);
+  });
+}
+
+function initFilters() {
+  const container = document.getElementById('categoryFilters');
+  const cats = ['all', 'health', 'productivity', 'relationship', 'discipline'];
+  cats.forEach(cat => {
+    const btn = document.createElement('button');
+    btn.textContent = cat[0].toUpperCase() + cat.slice(1);
+    btn.dataset.category = cat;
+    if (cat === 'all') btn.classList.add('active');
+    btn.addEventListener('click', () => {
+      currentCategory = cat;
+      container.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      render();
+    });
+    container.appendChild(btn);
+  });
+}
+
+function render() {
+  const list = document.getElementById('questList');
+  const comp = document.getElementById('completedList');
+  list.innerHTML = '';
+  comp.innerHTML = '';
+
+  const active = getActiveTasks(currentCategory);
+  const done = getCompletedTasks();
+
+  active.forEach(task => list.appendChild(createCard(task)));
+  done.forEach(task => comp.appendChild(createCard(task, true)));
+}
+
+function createCard(task, isCompleted = false) {
+  const card = document.createElement('div');
+  card.className = 'quest-card' + (isCompleted ? ' completed' : '');
+  card.dataset.id = task.id;
+
+  const title = document.createElement('h4');
+  title.className = 'quest-title typewriter';
+  typeText(title, task.title);
+
+  const desc = document.createElement('p');
+  desc.className = 'quest-desc typewriter';
+  typeText(desc, task.description);
+
+  const meta = document.createElement('div');
+  const badge = document.createElement('span');
+  badge.className = 'badge priority-' + task.priority;
+  badge.textContent = task.priority;
+  meta.appendChild(badge);
+  if (task.dueDate) {
+    const due = document.createElement('span');
+    due.className = 'due-date';
+    due.textContent = '🗓 ' + task.dueDate;
+    meta.appendChild(due);
+  }
+  if (task.companionId) {
+    const comp = companions[task.companionId];
+    if (comp) {
+      const cspan = document.createElement('span');
+      cspan.textContent = `👥 ${comp.name}`;
+      meta.appendChild(cspan);
+    }
+  }
+  card.appendChild(title);
+  card.appendChild(desc);
+  card.appendChild(meta);
+
+  if (!isCompleted) {
+    const btn = document.createElement('button');
+    btn.className = 'complete-btn';
+    btn.textContent = 'Complete';
+    btn.addEventListener('click', () => completeHandler(task, card));
+    card.appendChild(btn);
+  }
+  return card;
+}
+
+function completeHandler(task, card) {
+  card.classList.add('completed');
+  spawnParticles(card);
+  const updated = completeTask(task.id);
+  if (window.addXP) window.addXP(task.xp);
+  if (window.getCoins && window.setCoins) {
+    const coins = window.getCoins() + task.coins;
+    window.setCoins(coins);
+    if (document.getElementById('coinCount'))
+      document.getElementById('coinCount').textContent = coins;
+  }
+  if (window.updateXPBar) window.updateXPBar();
+  updateRewardDisplay();
+  setTimeout(render, 500);
+}
+
+function spawnParticles(card) {
+  for (let i = 0; i < 10; i++) {
+    const p = document.createElement('span');
+    p.className = 'particle';
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 40 * Math.random();
+    p.style.setProperty('--x', Math.cos(angle) * distance + 'px');
+    p.style.setProperty('--y', Math.sin(angle) * distance + 'px');
+    card.appendChild(p);
+    setTimeout(() => p.remove(), 600);
+  }
+}
+
+function openModal(prefill = null) {
+  const modal = document.getElementById('questModal');
+  modal.classList.remove('hidden');
+  document.getElementById('modalTitle').textContent = prefill ? 'Edit Quest' : 'New Quest';
+  document.getElementById('questTitle').value = prefill?.title || '';
+  document.getElementById('questDesc').value = prefill?.description || '';
+  document.getElementById('questPriority').value = prefill?.priority || 'medium';
+  document.getElementById('questCategory').value = prefill?.category || 'health';
+  document.getElementById('questDue').value = prefill?.dueDate || '';
+  document.getElementById('questRecurring').checked = prefill?.isRecurring || false;
+  document.getElementById('questRecurrence').classList.toggle('hidden', !(prefill?.isRecurring));
+  document.getElementById('questRecurrence').value = prefill?.recurrence || 'daily';
+  document.getElementById('questCompanion').value = prefill?.companionId || '';
+  modal.dataset.editId = prefill && prefill.id ? prefill.id : '';
+}
+
+function closeModal() {
+  const modal = document.getElementById('questModal');
+  modal.classList.add('hidden');
+  modal.dataset.editId = '';
+  document.getElementById('questForm').reset();
+  document.getElementById('questRecurrence').classList.add('hidden');
+}
+
+function saveQuest(e) {
+  e.preventDefault();
+  const modal = document.getElementById('questModal');
+  const data = {
+    title: document.getElementById('questTitle').value.trim(),
+    description: document.getElementById('questDesc').value.trim(),
+    priority: document.getElementById('questPriority').value,
+    category: document.getElementById('questCategory').value,
+    dueDate: document.getElementById('questDue').value,
+    isRecurring: document.getElementById('questRecurring').checked,
+    recurrence: document.getElementById('questRecurrence').value,
+    companionId: document.getElementById('questCompanion').value
+  };
+  addTask(data);
+  closeModal();
+  render();
+}
+
+function updateRewardDisplay() {
+  if (window.getXP) {
+    document.getElementById('questXP').textContent = window.getXP() + ' XP';
+  }
+  if (window.getCoins) {
+    document.getElementById('questCoins').textContent = window.getCoins() + ' 🪙';
+  }
+}
+
+function typeText(el, text) {
+  el.textContent = '';
+  let i = 0;
+  const interval = setInterval(() => {
+    el.textContent += text.charAt(i);
+    i++;
+    if (i >= text.length) clearInterval(interval);
+  }, 20);
+}
+
+export { render };


### PR DESCRIPTION
## Summary
- add dedicated quest log UI with priority badges, categories, and companion assignment
- implement task data and engine modules with localStorage, recurrence, and companion reactions
- introduce AI quest generator plus animated completion effects and reward tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e1105e1f4832abdcda19a7755aff2