### PR TITLE
Fix portrait generation: server fetches image and returns base64

### DIFF
--- a/api/image.js
+++ b/api/image.js
@@ -3,14 +3,26 @@ export default async function handler(req, res) {
   const apiKey = req.headers['x-xai-key'] || process.env.XAI_KEY;
   if (!apiKey) return res.status(500).json({ error: 'XAI_KEY not configured' });
   try {
-    const response = await fetch('https://api.x.ai/v1/images/generations', {
+    const { prompt, model, n } = req.body;
+    const xaiRes = await fetch('https://api.x.ai/v1/images/generations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
-      body: JSON.stringify(req.body),
+      body: JSON.stringify({ prompt, model, n, response_format: 'url' }),
     });
-    const data = await response.json();
-    if (!response.ok) return res.status(response.status).json(data);
-    return res.status(200).json(data);
+    const data = await xaiRes.json();
+    if (!xaiRes.ok) return res.status(xaiRes.status).json(data);
+
+    const imageUrl = data?.data?.[0]?.url;
+    if (!imageUrl) return res.status(500).json({ error: 'No image URL in xAI response' });
+
+    // Fetch the image and convert to base64 so the client gets a permanent data URL
+    const imgRes = await fetch(imageUrl);
+    if (!imgRes.ok) return res.status(500).json({ error: 'Failed to fetch generated image' });
+    const buffer = await imgRes.arrayBuffer();
+    const b64 = Buffer.from(buffer).toString('base64');
+    const mime = imgRes.headers.get('content-type') || 'image/jpeg';
+
+    return res.status(200).json({ data: [{ b64_json: b64, mime }] });
   } catch (error) {
     return res.status(500).json({ error: error.message });
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -564,7 +564,7 @@ export default function App() {
 
   // ── API: AI Image ─────────────────────────────────────────────────────────
   async function generateImage(companion) {
-    set(s => ({ generatingImage: { ...s.generatingImage, [companion.id]: true } }));
+    set(s => ({ generatingImage: { ...s.generatingImage, [companion.id]: true }, imageError: { ...s.imageError, [companion.id]: null } }));
     try {
       const prompt = `anime style portrait, ${companion.race.toLowerCase()} girl, ${companion.hair} hair, ${companion.eyes} eyes, ${companion.body} build, ${companion.class.toLowerCase()} dark fantasy outfit, dramatic lighting, beautiful, detailed, masterpiece`;
       const imgHeaders = { 'Content-Type': 'application/json' };
@@ -572,18 +572,24 @@ export default function App() {
       const res  = await fetch('/api/image', {
         method: 'POST',
         headers: imgHeaders,
-        body: JSON.stringify({ prompt, model: 'grok-2-image', n: 1, response_format: 'b64_json' }),
+        body: JSON.stringify({ prompt, model: 'grok-2-image', n: 1 }),
       });
       const data = await res.json();
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
       const b64 = data?.data?.[0]?.b64_json;
+      const mime = data?.data?.[0]?.mime || 'image/jpeg';
       if (b64) {
-        const dataUrl = `data:image/jpeg;base64,${b64}`;
+        const dataUrl = `data:${mime};base64,${b64}`;
         setState(s => ({
           ...s,
           companions: s.companions.map(c => c.id === companion.id ? { ...c, aiImage: dataUrl } : c),
         }));
+      } else {
+        throw new Error('No image data returned');
       }
-    } catch (e) { console.error('Image gen error:', e); }
+    } catch (e) {
+      set(s => ({ imageError: { ...s.imageError, [companion.id]: e.message } }));
+    }
     set(s => ({ generatingImage: { ...s.generatingImage, [companion.id]: false } }));
   }
 
@@ -990,6 +996,9 @@ export default function App() {
                     <Btn ghost small disabled={!!state.generatingImage[selComp.id]} onClick={() => generateImage(selComp)}>
                       {state.generatingImage[selComp.id] ? '...' : '✨ Portrait'}
                     </Btn>
+                    {state.imageError?.[selComp.id] && (
+                      <div style={{ fontSize: 10, color: S.red, marginTop: 4, maxWidth: 96, wordBreak: 'break-word' }}>{state.imageError[selComp.id]}</div>
+                    )}
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontFamily: 'Cinzel, serif', color: S.gold, fontSize: 15, marginBottom: 2 }}>{selComp.name}</div>


### PR DESCRIPTION
xAI doesn't reliably support b64_json response format. The API handler now requests a URL from xAI, fetches the image server-side, and returns it as base64 — so the client always gets a permanent data URL. Also adds visible error messages below the Portrait button so failures are no longer silent.

https://claude.ai/code/session_01PueTQZ27a5TaVNHsL46uu3