### PR TITLE
Move NovelAI key from request header to body to fix iOS Safari fetch …

### DIFF
--- a/api/image.js
+++ b/api/image.js
@@ -5,10 +5,9 @@ const NAI_NEGATIVE = "lowres, bad anatomy, bad hands, text, error, missing finge
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
-  const apiKey = req.headers['x-novelai-key'] || process.env.NOVELAI_KEY;
+  const { prompt, negative_prompt, width = 832, height = 1216, cacheKey, novelaiKey } = req.body;
+  const apiKey = novelaiKey || req.headers['x-novelai-key'] || process.env.NOVELAI_KEY;
   if (!apiKey) return res.status(500).json({ error: 'NOVELAI_KEY not configured' });
-
-  const { prompt, negative_prompt, width = 832, height = 1216, cacheKey } = req.body;
 
   if (cacheKey && serverCache.has(cacheKey)) {
     return res.status(200).json({ b64: serverCache.get(cacheKey), mime: 'image/png', cached: true });

--- a/api/scene.js
+++ b/api/scene.js
@@ -5,10 +5,9 @@ const NAI_NEGATIVE = "lowres, bad anatomy, bad hands, text, error, missing finge
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
-  const apiKey = req.headers['x-novelai-key'] || process.env.NOVELAI_KEY;
+  const { prompt, negative_prompt, width = 1216, height = 832, cacheKey, novelaiKey } = req.body;
+  const apiKey = novelaiKey || req.headers['x-novelai-key'] || process.env.NOVELAI_KEY;
   if (!apiKey) return res.status(500).json({ error: 'NOVELAI_KEY not configured' });
-
-  const { prompt, negative_prompt, width = 1216, height = 832, cacheKey } = req.body;
 
   if (cacheKey && serverCache.has(cacheKey)) {
     return res.status(200).json({ b64: serverCache.get(cacheKey), mime: 'image/png', cached: true });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -606,11 +606,10 @@ export default function App() {
     try {
       const prompt = buildCompanionPrompt(companion, ot);
       const negative_prompt = buildNegativePrompt(ot);
-      const headers = { 'Content-Type': 'application/json' };
-      if (keys.novelai) headers['x-novelai-key'] = keys.novelai.trim();
       const res = await fetch('/api/image', {
-        method: 'POST', headers,
-        body: JSON.stringify({ prompt, negative_prompt, cacheKey: cKey }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, negative_prompt, cacheKey: cKey, novelaiKey: keys.novelai?.trim() }),
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
@@ -630,11 +629,10 @@ export default function App() {
     setGeneratingScene(p => ({ ...p, [id]: true }));
     try {
       const prompt = type === 'region' ? buildRegionPrompt(id) : buildBossPrompt(id);
-      const headers = { 'Content-Type': 'application/json' };
-      if (keys.novelai) headers['x-novelai-key'] = keys.novelai.trim();
       const res = await fetch('/api/scene', {
-        method: 'POST', headers,
-        body: JSON.stringify({ prompt, width: 1216, height: 832, cacheKey: cKey }),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, width: 1216, height: 832, cacheKey: cKey, novelaiKey: keys.novelai?.trim() }),
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.error);
@@ -1460,11 +1458,10 @@ export default function App() {
                 <div style={{ marginTop: 8 }}>
                   <Btn ghost small onClick={async () => {
                     try {
-                      const headers = { 'Content-Type': 'application/json' };
-                      if (keys.novelai) headers['x-novelai-key'] = keys.novelai.trim();
                       const res = await fetch('/api/image', {
-                        method: 'POST', headers,
-                        body: JSON.stringify({ prompt: 'best quality, 1girl, simple background, test', width: 64, height: 64 }),
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ prompt: 'best quality, 1girl, simple background, test', width: 512, height: 512, novelaiKey: keys.novelai?.trim() }),
                       });
                       const data = await res.json();
                       if (data.error) alert('Error: ' + data.error);


### PR DESCRIPTION
…error

iOS Safari strictly validates custom header values and throws 'string did not match expected pattern' for certain key formats. Sending the key in the JSON body instead sidesteps this entirely. Also bumped test dimensions to 512x512 (64x64 is below NovelAI minimum).

https://claude.ai/code/session_01PueTQZ27a5TaVNHsL46uu3