### PR TITLE
Fix vercel.json - remove API rewrite that caused 404 on functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,10 @@
 {
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "functions": {
     "api/*.js": { "maxDuration": 60 }
   },
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
The "/api/(.*)" rewrite was intercepting requests before Vercel's native function routing could handle them, returning a 404. Also added outputDirectory and buildCommand for correct static serving.

https://claude.ai/code/session_01PueTQZ27a5TaVNHsL46uu3